### PR TITLE
【Fixed】デフォルトで helper と assets ファイルが生成されないように改善

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -22,7 +22,6 @@ module Achive
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
-
     config.action_view.field_error_proc = proc { |html_tag, instance| html_tag }
 
     config.generators do |g|


### PR DESCRIPTION
#1 

config/apprication.rb
```
    config.generators do |g|
      g.assets     false
      g.helper     false
   end
```